### PR TITLE
Mandelbrot: remove `inline` from `createComplex` for classes

### DIFF
--- a/cases/mandelbrot/BMMandelbrotCode.hx
+++ b/cases/mandelbrot/BMMandelbrotCode.hx
@@ -91,7 +91,7 @@ class BMMandelbrotCode {
 			i:inI, j:inJ
 		};
 	#else
-	inline public function createComplex(inI:Float, inJ:Float)
+	public function createComplex(inI:Float, inJ:Float)
 		return new Complex(inI, inJ);
 	#end
 


### PR DESCRIPTION
Inlining significantly affects performance of this benchmark on some targets (e.g. ovet 30% faster with `inline` for php).
To be able to compare anons performance to classes performance the benchmark should be the same for both cases.